### PR TITLE
update rev check for eMMC5.1 for `HW VERSION - rev_e`

### DIFF
--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -293,7 +293,7 @@ static int mmc_read_ext_csd(struct mmc_card *card, u8 *ext_csd)
 	}
 
 	card->ext_csd.rev = ext_csd[EXT_CSD_REV];
-	if (card->ext_csd.rev > 6) {
+	if (card->ext_csd.rev > 7) {
 		pr_err("%s: unrecognised EXT_CSD revision %d\n",
 			mmc_hostname(card->host), card->ext_csd.rev);
 		err = -EINVAL;


### PR DESCRIPTION
Archlinux Arm for flo is not able to boot on new rev of flo.

This patch is discussed [here](http://comments.gmane.org/gmane.linux.kernel.mmc/20496).

Here is `dmesg` before patching:

```
<3>[    3.737060] mmc0: unrecognised EXT_CSD revision 7
<3>[    3.737182] mmc0: error -22 whilst initialising MMC card
```

I will try recompile and post results here.
